### PR TITLE
feat : 역할 부여 기능 구현

### DIFF
--- a/src/main/java/com/project/mog/config/AdminInitializer.java
+++ b/src/main/java/com/project/mog/config/AdminInitializer.java
@@ -2,10 +2,19 @@ package com.project.mog.config;
 
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.repository.users.UsersRepository;
+import com.project.mog.service.role.RoleAssignmentDto;
+import com.project.mog.service.role.RolesDto;
 import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.auth.AuthRepository;
+import com.project.mog.repository.role.RoleAssignmentEntity;
+import com.project.mog.repository.role.RolesEntity;
+import com.project.mog.repository.role.RolesRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -17,11 +26,12 @@ public class AdminInitializer implements CommandLineRunner {
 
     private final UsersRepository usersRepository;
     private final AuthRepository authRepository;
+    private final RolesRepository rolesRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     public void run(String... args) throws Exception {
-        try {
+        
             // admin 계정이 이미 존재하는지 확인
             var existingAdmin = usersRepository.findByEmail("admin@mog.com");
             
@@ -32,9 +42,11 @@ public class AdminInitializer implements CommandLineRunner {
                         .nickName("admin")
                         .email("admin@mog.com")
                         .phoneNum("01000000000")
-                        .role("SUPER_ADMIN")
                         .build();
-
+                RolesEntity role = RolesEntity.builder().roleName("SUPER_ADMIN").roleDescription("SUPER_ADMIN").build();
+                RoleAssignmentEntity roleAssignment = RoleAssignmentEntity.builder().role(role).isActive(1L).assignedAt(LocalDateTime.now()).expiredAt(LocalDateTime.now().plusDays(30)).build();
+                roleAssignment.setUser(adminUser);
+                adminUser.setRoleAssignment(roleAssignment);
                 // AuthEntity 생성 (비밀번호 설정 - 평문)
                 AuthEntity adminAuth = new AuthEntity();
                 adminAuth.setPassword("admin1234");
@@ -42,25 +54,28 @@ public class AdminInitializer implements CommandLineRunner {
                 // 연관관계 설정
                 adminUser.setAuth(adminAuth);
                 adminAuth.setUser(adminUser);
-
                 // AuthEntity를 먼저 저장
                 authRepository.save(adminAuth);
                 
-                // UsersEntity 저장
-                usersRepository.save(adminUser);
                 
                 log.info("Super Admin 계정이 생성되었습니다: admin@mog.com / admin1234");
+
+                // //admin 생성 이후 역할 생성
+                RolesEntity userRole = RolesEntity.builder().roleName("USER").roleDescription("USER").build();
+                RolesEntity sellerRole = RolesEntity.builder().roleName("SELLER").roleDescription("SELLER").build();
+                rolesRepository.save(userRole);
+                rolesRepository.save(sellerRole);
+                log.info("역할이 정상적으로 생성되었습니다.");
+
             } else {
                 // 기존 admin 계정을 SUPER_ADMIN으로 업데이트
                 UsersEntity existingUser = existingAdmin.get();
-                if (!"SUPER_ADMIN".equals(existingUser.getRole())) {
-                    existingUser.setRole("SUPER_ADMIN");
+                if (!"SUPER_ADMIN".equals(existingUser.getRoleAssignment().getRole().getRoleName())) {
+                    existingUser.setRoleAssignment(RoleAssignmentDto.builder().rolesDto(RolesDto.builder().roleName("SUPER_ADMIN").build()).build().toEntity());
                     usersRepository.save(existingUser);
                     log.info("기존 admin 계정이 SUPER_ADMIN으로 업데이트되었습니다.");
                 }
             }
-        } catch (Exception e) {
-            log.error("Admin 계정 생성 중 오류 발생: {}", e.getMessage());
-        }
+        
     }
 }

--- a/src/main/java/com/project/mog/controller/users/UsersController.java
+++ b/src/main/java/com/project/mog/controller/users/UsersController.java
@@ -30,6 +30,10 @@ import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.security.jwt.JwtUtil;
 import com.project.mog.service.mail.MailDto;
 import com.project.mog.service.mail.MailService;
+import com.project.mog.service.role.RoleAssignmentDto;
+import com.project.mog.service.role.RoleRequestDto;
+import com.project.mog.service.role.RolesDto;
+import com.project.mog.service.role.RolesService;
 import com.project.mog.service.users.UsersDto;
 import com.project.mog.service.users.UsersInfoDto;
 import com.project.mog.service.users.UsersService;
@@ -48,6 +52,7 @@ public class UsersController implements UsersControllerDocs{
 	private final JwtUtil jwtUtil;
 	private final UsersService usersService;
 	private final MailService mailService;
+	private final RolesService rolesService;
 	
 	
 	@GetMapping("list")
@@ -95,7 +100,7 @@ public class UsersController implements UsersControllerDocs{
 		
 		long usersId = usersDto.getUsersId();
 		String email = usersDto.getEmail();
-		String role = usersDto.getRole();
+		String role = usersDto.getRoleAssignmentDto().getRolesDto().getRoleName();
 		String accessToken = jwtUtil.generateAccessToken(email);
 		String refreshToken = jwtUtil.generateRefreshToken(email);
 		
@@ -116,7 +121,7 @@ public class UsersController implements UsersControllerDocs{
 		UsersDto usersDto = usersService.socialLogin(request);
 		long usersId = usersDto.getUsersId();
 		String email = usersDto.getEmail();
-		String role = usersDto.getRole();
+		String role = usersDto.getRoleAssignmentDto().getRolesDto().getRoleName();
 		String accessToken = jwtUtil.generateAccessToken(email);
 		String refreshToken = jwtUtil.generateRefreshToken(email);
 		
@@ -172,4 +177,12 @@ public class UsersController implements UsersControllerDocs{
 		return ResponseEntity.status(HttpStatus.OK).body("비밀번호 찾기 이메일 전송 완료");
 	}
 	
+	@Transactional
+	@PostMapping("role/request")
+	public ResponseEntity<RolesDto> requestRoleAssignment(@RequestHeader("Authorization") String authHeader, @RequestBody RoleRequestDto roleRequestDto) {
+		String token = authHeader.replace("Bearer ", "");
+		String authEmail = jwtUtil.extractUserEmail(token);
+		RoleAssignmentDto roleAssignmentDto = rolesService.requestRoleAssignment(roleRequestDto,authEmail);
+		return ResponseEntity.status(HttpStatus.OK).body(roleAssignmentDto.getRolesDto());
+	}
 }

--- a/src/main/java/com/project/mog/repository/role/RoleAssignmentEntity.java
+++ b/src/main/java/com/project/mog/repository/role/RoleAssignmentEntity.java
@@ -1,0 +1,67 @@
+package com.project.mog.repository.role;
+
+import java.time.LocalDateTime;
+
+import com.project.mog.repository.users.UsersEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="roleassignment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoleAssignmentEntity {
+    @Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_ROLE_ASSIGNMENT_GENERATOR",sequenceName = "SEQ_ROLE_ASSIGNMENT",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_ROLE_ASSIGNMENT_GENERATOR" )	
+	private Long assignmentId;
+
+    @Column(nullable=false)
+    private Long isActive;
+
+    @Column(nullable=true,updatable = false)
+	private LocalDateTime assignedAt;
+    
+    @Column(nullable=true)
+    private LocalDateTime expiredAt;
+
+    @PrePersist//영속화 되기전 아래 메소드 실행
+	public void setAssignedAt() {
+		this.assignedAt= LocalDateTime.now();
+		this.expiredAt=LocalDateTime.now().plusDays(30);
+	}
+	@PreUpdate//영속화 되기전 아래 메소드 실행
+	public void setExpiredAt() {
+		this.expiredAt= LocalDateTime.now().plusDays(30);		
+	}
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "usersId", referencedColumnName = "usersId", nullable = false)
+    private UsersEntity user;
+
+    @ManyToOne( cascade = CascadeType.ALL)
+    @JoinColumn(name = "roleId", referencedColumnName = "roleId", nullable = false)
+    private RolesEntity role;
+}

--- a/src/main/java/com/project/mog/repository/role/RoleAssignmentRepository.java
+++ b/src/main/java/com/project/mog/repository/role/RoleAssignmentRepository.java
@@ -1,0 +1,9 @@
+package com.project.mog.repository.role;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RoleAssignmentRepository extends JpaRepository<RoleAssignmentEntity, Long> {
+    @Query(nativeQuery = true,value="SELECT * FROM ROLEASSIGNMENT WHERE ROLEASSIGNMENT.USERSID=?1")
+    RoleAssignmentEntity findByUsersId(Long usersId);
+}

--- a/src/main/java/com/project/mog/repository/role/RolePermissions.java
+++ b/src/main/java/com/project/mog/repository/role/RolePermissions.java
@@ -1,0 +1,46 @@
+package com.project.mog.repository.role;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="rolepermissions")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RolePermissions {
+    @Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_ROLE_PERMISSIONS_GENERATOR",sequenceName = "SEQ_ROLE_PERMISSIONS",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_ROLE_PERMISSIONS_GENERATOR" )	
+	private Long permissionId;
+
+    @Column(length=20,nullable=false)
+    private String permissionName;
+
+    @Column(nullable=false)
+    private String permissionsCategory;
+
+    @Column(nullable=false)
+    private String permissionsDescription;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roleId", referencedColumnName = "roleId", nullable = false)
+    private RolesEntity role;
+    
+}

--- a/src/main/java/com/project/mog/repository/role/RolesEntity.java
+++ b/src/main/java/com/project/mog/repository/role/RolesEntity.java
@@ -1,0 +1,45 @@
+package com.project.mog.repository.role;
+
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="roles")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RolesEntity {
+    @Id
+	@Column(length=19,nullable=false)
+	@SequenceGenerator(name = "SEQ_ROLE_GENERATOR",sequenceName = "SEQ_ROLE",allocationSize = 1,initialValue = 1)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE,generator ="SEQ_ROLE_GENERATOR" )	
+	private Long roleId;
+
+    @Column(length=20,nullable=false,unique=true)
+    private String roleName;
+
+    @Column(nullable=false)
+    private String roleDescription;
+
+
+
+    @OneToMany(mappedBy = "role", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<RoleAssignmentEntity> roleAssignments;
+}

--- a/src/main/java/com/project/mog/repository/role/RolesRepository.java
+++ b/src/main/java/com/project/mog/repository/role/RolesRepository.java
@@ -1,0 +1,9 @@
+package com.project.mog.repository.role;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RolesRepository extends JpaRepository<RolesEntity, Long> {
+    Optional<RolesEntity> findByRoleName(String roleName);
+}

--- a/src/main/java/com/project/mog/repository/users/UsersEntity.java
+++ b/src/main/java/com/project/mog/repository/users/UsersEntity.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.bios.BiosEntity;
+import com.project.mog.repository.role.RoleAssignmentEntity;
 
 import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
@@ -55,10 +56,7 @@ public class UsersEntity {
 	
 	@Column(length=11,nullable=false)
 	private String phoneNum;
-	
-	@Column(length=20,nullable=false)
-	private String role;
-	
+
 	@Column(nullable=false,updatable = false)
 	private LocalDateTime regDate;
 	@Column(nullable=false)
@@ -77,5 +75,7 @@ public class UsersEntity {
 	private BiosEntity bios;
 	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
 	private AuthEntity auth;
+	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	private RoleAssignmentEntity roleAssignment;
 
 }

--- a/src/main/java/com/project/mog/security/UsersDetails.java
+++ b/src/main/java/com/project/mog/security/UsersDetails.java
@@ -19,7 +19,7 @@ public class UsersDetails implements UserDetails {
 	
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		String role = usersEntity.getRole();
+		String role = usersEntity.getRoleAssignment().getRole().getRoleName();
 		
 		// 역할에 따른 권한 부여
 		switch (role) {

--- a/src/main/java/com/project/mog/service/role/RoleAssignmentDto.java
+++ b/src/main/java/com/project/mog/service/role/RoleAssignmentDto.java
@@ -1,0 +1,45 @@
+package com.project.mog.service.role;
+
+import java.time.LocalDateTime;
+
+import com.project.mog.repository.role.RoleAssignmentEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoleAssignmentDto {
+    private Long assignmentId;
+    private Long isActive;
+    private LocalDateTime assignedAt;
+    private LocalDateTime expiredAt;
+    private RolesDto rolesDto;
+
+    public RoleAssignmentEntity toEntity() {
+        return RoleAssignmentEntity.builder()
+                .assignmentId(assignmentId)
+                .isActive(isActive)
+                .assignedAt(assignedAt)
+                .expiredAt(expiredAt)
+                .role(rolesDto.toEntity())
+                .build();
+    }
+
+    public static RoleAssignmentDto toDto(RoleAssignmentEntity rEntity) {
+        return RoleAssignmentDto.builder()
+                .assignmentId(rEntity.getAssignmentId())
+                .isActive(rEntity.getIsActive())
+                .assignedAt(rEntity.getAssignedAt())
+                .expiredAt(rEntity.getExpiredAt())
+                .rolesDto(RolesDto.toDto(rEntity.getRole()))
+                .build();
+    }
+    
+}

--- a/src/main/java/com/project/mog/service/role/RoleRequestDto.java
+++ b/src/main/java/com/project/mog/service/role/RoleRequestDto.java
@@ -1,0 +1,12 @@
+package com.project.mog.service.role;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RoleRequestDto {
+    private String roleName;
+}

--- a/src/main/java/com/project/mog/service/role/RolesDto.java
+++ b/src/main/java/com/project/mog/service/role/RolesDto.java
@@ -1,0 +1,37 @@
+package com.project.mog.service.role;
+
+import com.project.mog.repository.role.RolesEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RolesDto {
+    private Long roleId;
+    private String roleName;
+    private String roleDescription;
+
+    public RolesEntity toEntity() {
+        return RolesEntity.builder()
+                .roleName(roleName)
+                .roleDescription(roleDescription)
+                .build();
+    }
+
+    public static RolesDto toDto(RolesEntity rEntity) {
+        return RolesDto.builder()
+                .roleId(rEntity.getRoleId())
+                .roleName(rEntity.getRoleName())
+                .roleDescription(rEntity.getRoleDescription())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/project/mog/service/role/RolesService.java
+++ b/src/main/java/com/project/mog/service/role/RolesService.java
@@ -1,0 +1,49 @@
+package com.project.mog.service.role;
+
+import org.springframework.stereotype.Service;
+
+import com.project.mog.repository.role.RoleAssignmentEntity;
+import com.project.mog.repository.role.RoleAssignmentRepository;
+import com.project.mog.repository.role.RolesEntity;
+import com.project.mog.repository.role.RolesRepository;
+import com.project.mog.repository.users.UsersEntity;
+import com.project.mog.repository.users.UsersRepository;
+
+@Service
+public class RolesService {
+    private final UsersRepository usersRepository;
+    private final RolesRepository rolesRepository;
+    private final RoleAssignmentRepository roleAssignmentRepository;
+    
+    public RolesService(UsersRepository usersRepository,  RolesRepository rolesRepository,RoleAssignmentRepository roleAssignmentRepository) {
+        this.usersRepository = usersRepository;
+        this.rolesRepository = rolesRepository;
+        this.roleAssignmentRepository = roleAssignmentRepository;
+    }
+    
+    public RoleAssignmentDto requestRoleAssignment(RoleRequestDto roleRequestDto, String authEmail) {
+        UsersEntity usersEntity = usersRepository.findByEmail(authEmail).orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다"));
+        RoleAssignmentEntity roleAssignmentEntity = roleAssignmentRepository.findByUsersId(usersEntity.getUsersId());
+        if (roleAssignmentEntity.getRole().getRoleName().equals("SUPER_ADMIN")) {
+            throw new IllegalArgumentException("최고 관리자는 역할을 변경할 수 없습니다");
+        }
+        if (roleAssignmentEntity.getRole().getRoleName().equals(roleRequestDto.getRoleName())) {
+            throw new IllegalArgumentException("이미 해당 역할을 가지고 있습니다");
+        }
+        if (!roleAssignmentEntity.getRole().getRoleName().equals(roleRequestDto.getRoleName())) {
+            RolesEntity rolesEntity = rolesRepository.findByRoleName(roleRequestDto.getRoleName()).orElseThrow(() -> new IllegalArgumentException("해당 역할을 찾을 수 없습니다"));
+            roleAssignmentEntity.setRole(rolesEntity);
+            roleAssignmentEntity.setIsActive(0L);
+            roleAssignmentEntity.setExpiredAt(null);
+            roleAssignmentEntity.setAssignedAt(null);
+            roleAssignmentRepository.save(roleAssignmentEntity);    
+
+            return RoleAssignmentDto.toDto(roleAssignmentEntity);
+        }
+        
+        return RoleAssignmentDto.toDto(roleAssignmentEntity);
+        
+        
+    }
+    
+}

--- a/src/main/java/com/project/mog/service/users/UsersDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersDto.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 
 import com.project.mog.repository.auth.AuthEntity;
 import com.project.mog.repository.bios.BiosEntity;
+import com.project.mog.repository.role.RoleAssignmentEntity;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.service.auth.AuthDto;
 import com.project.mog.service.bios.BiosDto;
+import com.project.mog.service.role.RoleAssignmentDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -28,6 +30,7 @@ public class UsersDto {
 	@Nullable
 	private BiosDto biosDto;
 	private AuthDto authDto;
+	private RoleAssignmentDto roleAssignmentDto;
 	@Schema(description = "usersName",example="테스트유저")
 	private String usersName;
 	@Schema(description = "nickName",example="테스트닉네임")
@@ -38,8 +41,7 @@ public class UsersDto {
 	private String profileImg;
 	@Schema(description = "phoneNum", example="01012345678")
 	private String phoneNum;
-	@Schema(description = "role", example="USER")
-	private String role;
+	
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
@@ -51,7 +53,7 @@ public class UsersDto {
 					.email(email)
 					.profileImg(profileImg)
 					.phoneNum(phoneNum)
-					.role(role) 
+					.roleAssignment(roleAssignmentDto.toEntity()) 
 					.regDate(regDate) 
 					.updateDate(updateDate) 
 					.bios(Optional.ofNullable(biosDto).map(BiosDto::toEntity).orElse(null))
@@ -67,6 +69,11 @@ public class UsersDto {
 			aEntity.setUser(uEntity);
 			uEntity.setAuth(aEntity);
 		}
+		if(roleAssignmentDto!=null) {
+			RoleAssignmentEntity rEntity = roleAssignmentDto.toEntity();
+			rEntity.setUser(uEntity);
+			uEntity.setRoleAssignment(rEntity);
+		}
 		return uEntity;
 	}
 	
@@ -79,7 +86,7 @@ public class UsersDto {
 				.email(uEntity.getEmail())
 				.profileImg(uEntity.getProfileImg())
 				.phoneNum(uEntity.getPhoneNum())
-				.role(uEntity.getRole())
+				.roleAssignmentDto(RoleAssignmentDto.toDto(uEntity.getRoleAssignment()))
 				.regDate(uEntity.getRegDate())
 				.updateDate(uEntity.getUpdateDate())
 				.biosDto(BiosDto.toDto(uEntity.getBios()))

--- a/src/main/java/com/project/mog/service/users/UsersInfoDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersInfoDto.java
@@ -7,6 +7,7 @@ import com.project.mog.repository.bios.BiosEntity;
 import com.project.mog.repository.users.UsersEntity;
 import com.project.mog.service.auth.AuthDto;
 import com.project.mog.service.bios.BiosDto;
+import com.project.mog.service.role.RoleAssignmentDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
@@ -37,7 +38,7 @@ public class UsersInfoDto {
 	@Schema(description = "phoneNum", example="01012345678")
 	private String phoneNum;
 	@Schema(description = "role", example="USER")
-	private String role;
+	private RoleAssignmentDto roleAssignmentDto;
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
@@ -47,7 +48,7 @@ public class UsersInfoDto {
 		user.setNickName(nickName);
 		user.setProfileImg(profileImg);
 		user.setPhoneNum(phoneNum);
-		user.setRole(role);
+		user.setRoleAssignment(roleAssignmentDto.toEntity());
 		user.setUpdateDate(LocalDateTime.now());
 		
 		if(biosDto!=null) {
@@ -68,7 +69,7 @@ public class UsersInfoDto {
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
 				.phoneNum(user.getPhoneNum())
-				.role(user.getRole())
+				.roleAssignmentDto(RoleAssignmentDto.toDto(user.getRoleAssignment()))
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))
@@ -82,7 +83,7 @@ public class UsersInfoDto {
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
 				.phoneNum(user.getPhoneNum())
-				.role(user.getRole())
+				.roleAssignmentDto(RoleAssignmentDto.toDto(user.getRoleAssignment()))
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))


### PR DESCRIPTION
1. 역할 부여 기능 구현
- 역할 신청시 관리자에게 권한 신청을 위해 isActive : 0, assignedAt:null, expiredAt: null 설정
  - 관리자 허가시 변경 구현 예정
- ERD 설정에 따라 RoleAssignment, Roles, RolePermissions 추가 및 연관관계 설정
- Role 구현에 따라 Users에 지정된 role 제거 및 RoleAssignmentEntity 연결
- 변경된 Role에 따라 AdminInitializer 재설정
- 역할 신청시 Roles에 등록된 Unique한 Role로 설정하도록 RequestBody에 입력된 Role을 Roles에서 찾아 강제치환, RoleAssignment는 그대로 추가