### PR TITLE
hotfix : role 수정 후 사용자 정보 수정 api 에러 해결

### DIFF
--- a/src/main/java/com/project/mog/service/users/UsersInfoDto.java
+++ b/src/main/java/com/project/mog/service/users/UsersInfoDto.java
@@ -37,8 +37,6 @@ public class UsersInfoDto {
 	private String profileImg;
 	@Schema(description = "phoneNum", example="01012345678")
 	private String phoneNum;
-	@Schema(description = "role", example="USER")
-	private RoleAssignmentDto roleAssignmentDto;
 	private LocalDateTime regDate;
 	private LocalDateTime updateDate;
 	
@@ -48,7 +46,6 @@ public class UsersInfoDto {
 		user.setNickName(nickName);
 		user.setProfileImg(profileImg);
 		user.setPhoneNum(phoneNum);
-		user.setRoleAssignment(roleAssignmentDto.toEntity());
 		user.setUpdateDate(LocalDateTime.now());
 		
 		if(biosDto!=null) {
@@ -69,7 +66,6 @@ public class UsersInfoDto {
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
 				.phoneNum(user.getPhoneNum())
-				.roleAssignmentDto(RoleAssignmentDto.toDto(user.getRoleAssignment()))
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))
@@ -83,7 +79,6 @@ public class UsersInfoDto {
 				.profileImg(user.getProfileImg())
 				.nickName(user.getNickName())
 				.phoneNum(user.getPhoneNum())
-				.roleAssignmentDto(RoleAssignmentDto.toDto(user.getRoleAssignment()))
 				.regDate(user.getRegDate())
 				.updateDate(user.getUpdateDate())
 				.biosDto(BiosDto.toDto(user.getBios()))


### PR DESCRIPTION
1. role 수정 후 사용자 정보 수정 api 에러 해결
- UsersInfoDto에서 role 필드 제거
- UsersService에서 권한 변경 로직 제거
- 사용자의 신체정보가 없을 경우 생성하는 로직 추가
- 사용자 정보와 수정하려는 사용자와 아이디 불일치시 케이스 추가